### PR TITLE
Fix Makefile compatibility Pixel 9 series

### DIFF
--- a/IonStack/CVE-2026-43499/exploit/Makefile
+++ b/IonStack/CVE-2026-43499/exploit/Makefile
@@ -24,8 +24,8 @@ CORE_SRCS := \
   $(call pick_src,slide.c) \
   $(call pick_src,fops.c) \
   $(call pick_src,pipe.c) \
-  src/root.c
-PRELOAD_SRCS := $(CORE_SRCS) src/preload.c src/su_blob.S src/wallpaper_blob.S
+  $(call pick_src,root.c)
+PRELOAD_SRCS := $(CORE_SRCS) $(call pick_src,preload.c) src/su_blob.S src/wallpaper_blob.S
 
 .DEFAULT_GOAL := preload
 


### PR DESCRIPTION
The exploit implementation for Pixel 9 series devices relies on different root and preload files, but the makefile does not look for these in the target directories, causing a linker error when the compiled output is run through adb